### PR TITLE
Match bluefluff's "announce DLC" command

### DIFF
--- a/pyfluff/protocol.py
+++ b/pyfluff/protocol.py
@@ -220,9 +220,9 @@ class FurbyProtocol:
         # Filename is 12 bytes, padded with nulls
         filename_bytes = filename.encode("ascii")[:12].ljust(12, b"\x00")
         return bytes(
-            [GeneralPlusCommand.ANNOUNCE_DLC_UPLOAD.value]
+            [GeneralPlusCommand.ANNOUNCE_DLC_UPLOAD.value, 0x00]
             + list(size_bytes)
-            + [0x00, slot]
+            + [slot]
             + list(filename_bytes)
             + [0x00, 0x00]
         )


### PR DESCRIPTION
Partially fixes #1. I can't prove it's a total fix because (1) I don't have bluefluff running and (2) still haven't successfully flashed a DLC. I'm assuming bluefluff's implementation works, though, and this did get me further under PyFluff.

https://github.com/Jeija/bluefluff/blob/f21f706f3f0eb0f0ba4f6d6428b25f09b7e1087c/fluffd/fluffaction.js#L145